### PR TITLE
Add releases/bin2dsk.sh

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -25,7 +25,7 @@ Currently floppy disk images cannot be loaded while the Mac accesses a floppy di
 
 Before loading a different disk image it's recommended to eject the previously inserted disk image from within MacOS.
 
-Some system floppy disk images in matching dsk format can be found at [here](http://www.rolli.ch/MacPlus/welcome.html). Some nice applicatons on 400k dsk images can be found [here](http://tkc8800.com/page/Macintosh-128k-512k-disk-images). Official system disk images are available from apple e.g. via [ftp](http://ftp.iinet.net.au/pub/apple/US/Macintosh/System/Older_System/System_6.0.x/). Under Linux these can be converted into the desired dsk format using [Linux stuffit](http://web.archive.org/web/20060205025441/http://www.stuffit.com/downloads/files/stuffit520.611linux-i386.tar.gz), unar and [dc2dsk](http://www.bigmessowires.com/dc2dsk.c) in that order.
+Official system disk images are available from apple at [here](https://web.archive.org/web/20141025043714/http://www.info.apple.com/support/oldersoftwarelist.html). Under Linux these can be converted into the desired dsk format using [Linux stuffit](http://web.archive.org/web/20060205025441/http://www.stuffit.com/downloads/files/stuffit520.611linux-i386.tar.gz), unar and [dc2dsk](http://www.bigmessowires.com/dc2dsk.c) in that order. A shell script has been provided for convenience at [releases/bin2dsk.sh](releases/bin2dsk.sh).
 
 ## Hard disk support
 

--- a/releases/bin2dsk.sh
+++ b/releases/bin2dsk.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+set -euo pipefail
+
+STUFF_IT_URL="http://web.archive.org/web/20060205025441/http://www.stuffit.com/downloads/files/stuffit520.611linux-i386.tar.gz"
+DC2DSK_URL="http://www.bigmessowires.com/dc2dsk.c"
+
+function echo_err {
+  echo $@ 1>&2
+}
+
+# Check for input filename
+if [[ $# -ne 1 ]] || [[ ! -f ${INPUT_FILE:=$1} ]]; then
+  echo_err "Usage: $0 <INPUT_FILE>"
+  exit 2
+fi
+
+# Check that input is a compatable type
+if ! file $INPUT_FILE | grep "MacBinary II" >/dev/null; then
+  echo_err "Input file is not MacBinary II. This process only works with MacBinary II formatted bin files"
+  exit 2
+fi
+
+# Check for nesseary commands
+if ! command -v ${UNSTUFF_CMD:=unstuff} >/dev/null; then
+  echo_err "'unstuff' command is missing. Download it from $STUFF_IT_URL"
+  echo_err "The 'unstuff' command can be set by exporting path as 'UNSTUFF_CMD'"
+  exit 3
+fi
+
+if ! command -v ${UNAR_CMD:=unar} >/dev/null; then
+  echo_err "'unar' command is missing."
+  echo_err "The 'unar' command can be set by exporting path as 'UNAR_CMD'"
+  exit 3
+fi
+
+if ! command -v ${DC2DSK_CMD:=dc2dsk} >/dev/null; then
+  echo_err "'dc2dsk' command is missing."
+  echo_err "Source can be downloaded from $DC2DSK_URL and compiled with 'gcc -o dc2dsk dc2dsk.c'"
+  echo_err "The 'dc2dsk' command can be set by exporting path as 'DC2DSK_CMD'"
+  exit 3
+fi
+
+# Do the work
+mkdir ${TEMP_DIR:=$(pwd)/unstuffout-$RANDOM}
+$UNSTUFF_CMD --destination=$TEMP_DIR $INPUT_FILE
+$UNAR_CMD -o - $TEMP_DIR/*.data | $DC2DSK_CMD > ${INPUT_FILE:0:-4}.dsk
+rm -rf $TEMP_DIR


### PR DESCRIPTION
Shell script that uses StuffIt, Unar and ds2dsk to create a dsk from
Apple provided disk images.

Updated readme to remove dead links under floppy disk section and
provided a new link to Apples software on archive.org as the web page no
longer exists on the Apple website. Disk images are still available via
the Apple FTP but directly listing is disabled.