### PR TITLE
Adding support for second SCSI VHD mount.

### DIFF
--- a/MacPlus.qsf
+++ b/MacPlus.qsf
@@ -13,7 +13,7 @@ set_global_assignment -name PARTITION_NETLIST_TYPE SOURCE -section_id Top
 set_global_assignment -name PARTITION_FITTER_PRESERVATION_LEVEL PLACEMENT_AND_ROUTING -section_id Top
 set_global_assignment -name PARTITION_COLOR 16764057 -section_id Top
 
-set_global_assignment -name LAST_QUARTUS_VERSION "17.0.2 Standard Edition"
+set_global_assignment -name LAST_QUARTUS_VERSION "17.0.0 Standard Edition"
 
 set_global_assignment -name GENERATE_RBF_FILE ON
 set_global_assignment -name PROJECT_OUTPUT_DIRECTORY output_files
@@ -53,4 +53,349 @@ set_global_assignment -name SEED 1
 source sys/sys.tcl
 source sys/sys_analog.tcl
 source files.qip
+set_global_assignment -name ENABLE_SIGNALTAP ON
+set_global_assignment -name USE_SIGNALTAP_FILE stp1.stp
+set_global_assignment -name SIGNALTAP_FILE stp1.stp
+set_global_assignment -name SLD_NODE_CREATOR_ID 110 -section_id auto_signaltap_0
+set_global_assignment -name SLD_NODE_ENTITY_NAME sld_signaltap -section_id auto_signaltap_0
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_clk -to clk_sys -section_id auto_signaltap_0
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_trigger_in[0] -to "emu:emu|RESET" -section_id auto_signaltap_0
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_data_in[0] -to "emu:emu|RESET" -section_id auto_signaltap_0
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_storage_qualifier_in[0] -to "emu:emu|RESET" -section_id auto_signaltap_0
+set_global_assignment -name SLD_NODE_PARAMETER_ASSIGNMENT "SLD_RAM_BLOCK_TYPE=AUTO" -section_id auto_signaltap_0
+set_global_assignment -name SLD_NODE_PARAMETER_ASSIGNMENT "SLD_NODE_INFO=805334528" -section_id auto_signaltap_0
+set_global_assignment -name SLD_NODE_PARAMETER_ASSIGNMENT "SLD_POWER_UP_TRIGGER=0" -section_id auto_signaltap_0
+set_global_assignment -name SLD_NODE_PARAMETER_ASSIGNMENT "SLD_SEGMENT_SIZE=2048" -section_id auto_signaltap_0
+set_global_assignment -name SLD_NODE_PARAMETER_ASSIGNMENT "SLD_ATTRIBUTE_MEM_MODE=OFF" -section_id auto_signaltap_0
+set_global_assignment -name SLD_NODE_PARAMETER_ASSIGNMENT "SLD_STATE_FLOW_USE_GENERATED=0" -section_id auto_signaltap_0
+set_global_assignment -name SLD_NODE_PARAMETER_ASSIGNMENT "SLD_STATE_BITS=11" -section_id auto_signaltap_0
+set_global_assignment -name SLD_NODE_PARAMETER_ASSIGNMENT "SLD_BUFFER_FULL_STOP=1" -section_id auto_signaltap_0
+set_global_assignment -name SLD_NODE_PARAMETER_ASSIGNMENT "SLD_CURRENT_RESOURCE_WIDTH=1" -section_id auto_signaltap_0
+set_global_assignment -name SLD_NODE_PARAMETER_ASSIGNMENT "SLD_STORAGE_QUALIFIER_GAP_RECORD=1" -section_id auto_signaltap_0
+set_global_assignment -name SLD_NODE_PARAMETER_ASSIGNMENT "SLD_STORAGE_QUALIFIER_MODE=COMBINATIONAL" -section_id auto_signaltap_0
+set_global_assignment -name SLD_NODE_PARAMETER_ASSIGNMENT "SLD_INCREMENTAL_ROUTING=1" -section_id auto_signaltap_0
+set_instance_assignment -name POST_FIT_CONNECT_TO_SLD_NODE_ENTITY_PORT crc[0] -to auto_signaltap_0|vcc -section_id auto_signaltap_0
+set_instance_assignment -name POST_FIT_CONNECT_TO_SLD_NODE_ENTITY_PORT crc[1] -to auto_signaltap_0|vcc -section_id auto_signaltap_0
+set_instance_assignment -name POST_FIT_CONNECT_TO_SLD_NODE_ENTITY_PORT crc[2] -to auto_signaltap_0|vcc -section_id auto_signaltap_0
+set_instance_assignment -name POST_FIT_CONNECT_TO_SLD_NODE_ENTITY_PORT crc[4] -to auto_signaltap_0|vcc -section_id auto_signaltap_0
+set_instance_assignment -name POST_FIT_CONNECT_TO_SLD_NODE_ENTITY_PORT crc[10] -to auto_signaltap_0|vcc -section_id auto_signaltap_0
+set_instance_assignment -name POST_FIT_CONNECT_TO_SLD_NODE_ENTITY_PORT crc[12] -to auto_signaltap_0|vcc -section_id auto_signaltap_0
+set_instance_assignment -name POST_FIT_CONNECT_TO_SLD_NODE_ENTITY_PORT crc[14] -to auto_signaltap_0|vcc -section_id auto_signaltap_0
+set_instance_assignment -name POST_FIT_CONNECT_TO_SLD_NODE_ENTITY_PORT crc[15] -to auto_signaltap_0|vcc -section_id auto_signaltap_0
+set_instance_assignment -name POST_FIT_CONNECT_TO_SLD_NODE_ENTITY_PORT crc[16] -to auto_signaltap_0|vcc -section_id auto_signaltap_0
+set_instance_assignment -name POST_FIT_CONNECT_TO_SLD_NODE_ENTITY_PORT crc[18] -to auto_signaltap_0|vcc -section_id auto_signaltap_0
+set_instance_assignment -name POST_FIT_CONNECT_TO_SLD_NODE_ENTITY_PORT crc[20] -to auto_signaltap_0|vcc -section_id auto_signaltap_0
+set_instance_assignment -name POST_FIT_CONNECT_TO_SLD_NODE_ENTITY_PORT crc[21] -to auto_signaltap_0|vcc -section_id auto_signaltap_0
+set_instance_assignment -name POST_FIT_CONNECT_TO_SLD_NODE_ENTITY_PORT crc[22] -to auto_signaltap_0|vcc -section_id auto_signaltap_0
+set_instance_assignment -name POST_FIT_CONNECT_TO_SLD_NODE_ENTITY_PORT crc[23] -to auto_signaltap_0|gnd -section_id auto_signaltap_0
+set_instance_assignment -name POST_FIT_CONNECT_TO_SLD_NODE_ENTITY_PORT crc[24] -to auto_signaltap_0|vcc -section_id auto_signaltap_0
+set_instance_assignment -name POST_FIT_CONNECT_TO_SLD_NODE_ENTITY_PORT crc[27] -to auto_signaltap_0|vcc -section_id auto_signaltap_0
+set_instance_assignment -name POST_FIT_CONNECT_TO_SLD_NODE_ENTITY_PORT crc[28] -to auto_signaltap_0|vcc -section_id auto_signaltap_0
+set_instance_assignment -name POST_FIT_CONNECT_TO_SLD_NODE_ENTITY_PORT crc[31] -to auto_signaltap_0|gnd -section_id auto_signaltap_0
+set_global_assignment -name SLD_NODE_PARAMETER_ASSIGNMENT "SLD_TRIGGER_LEVEL=1" -section_id auto_signaltap_0
+set_global_assignment -name SLD_NODE_PARAMETER_ASSIGNMENT "SLD_SAMPLE_DEPTH=2048" -section_id auto_signaltap_0
+set_global_assignment -name SLD_NODE_PARAMETER_ASSIGNMENT "SLD_TRIGGER_IN_ENABLED=0" -section_id auto_signaltap_0
+set_global_assignment -name SLD_NODE_PARAMETER_ASSIGNMENT "SLD_TRIGGER_PIPELINE=0" -section_id auto_signaltap_0
+set_global_assignment -name SLD_NODE_PARAMETER_ASSIGNMENT "SLD_RAM_PIPELINE=0" -section_id auto_signaltap_0
+set_global_assignment -name SLD_NODE_PARAMETER_ASSIGNMENT "SLD_COUNTER_PIPELINE=0" -section_id auto_signaltap_0
+set_global_assignment -name SLD_NODE_PARAMETER_ASSIGNMENT "SLD_ADVANCED_TRIGGER_ENTITY=basic,1," -section_id auto_signaltap_0
+set_global_assignment -name SLD_NODE_PARAMETER_ASSIGNMENT "SLD_TRIGGER_LEVEL_PIPELINE=1" -section_id auto_signaltap_0
+set_global_assignment -name SLD_NODE_PARAMETER_ASSIGNMENT "SLD_ENABLE_ADVANCED_TRIGGER=0" -section_id auto_signaltap_0
+set_global_assignment -name SLD_NODE_PARAMETER_ASSIGNMENT "SLD_STORAGE_QUALIFIER_ENABLE_ADVANCED_CONDITION=0" -section_id auto_signaltap_0
+set_global_assignment -name SLD_NODE_PARAMETER_ASSIGNMENT "SLD_STORAGE_QUALIFIER_PIPELINE=1" -section_id auto_signaltap_0
+set_global_assignment -name SLD_NODE_PARAMETER_ASSIGNMENT "SLD_STORAGE_QUALIFIER_ADVANCED_CONDITION_ENTITY=basic,1," -section_id auto_signaltap_0
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_trigger_in[1] -to "emu:emu|dataController_top:dc0|ncr5380:scsi|bus_cs" -section_id auto_signaltap_0
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_trigger_in[2] -to "emu:emu|dataController_top:dc0|ncr5380:scsi|bus_rs[0]" -section_id auto_signaltap_0
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_trigger_in[3] -to "emu:emu|dataController_top:dc0|ncr5380:scsi|bus_rs[1]" -section_id auto_signaltap_0
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_trigger_in[4] -to "emu:emu|dataController_top:dc0|ncr5380:scsi|bus_rs[2]" -section_id auto_signaltap_0
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_trigger_in[5] -to "emu:emu|dataController_top:dc0|ncr5380:scsi|bus_we" -section_id auto_signaltap_0
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_trigger_in[6] -to "emu:emu|dataController_top:dc0|ncr5380:scsi|rdata[0]" -section_id auto_signaltap_0
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_trigger_in[7] -to "emu:emu|dataController_top:dc0|ncr5380:scsi|rdata[1]" -section_id auto_signaltap_0
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_trigger_in[8] -to "emu:emu|dataController_top:dc0|ncr5380:scsi|rdata[2]" -section_id auto_signaltap_0
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_trigger_in[9] -to "emu:emu|dataController_top:dc0|ncr5380:scsi|rdata[3]" -section_id auto_signaltap_0
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_trigger_in[10] -to "emu:emu|dataController_top:dc0|ncr5380:scsi|rdata[4]" -section_id auto_signaltap_0
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_trigger_in[11] -to "emu:emu|dataController_top:dc0|ncr5380:scsi|rdata[5]" -section_id auto_signaltap_0
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_trigger_in[12] -to "emu:emu|dataController_top:dc0|ncr5380:scsi|rdata[6]" -section_id auto_signaltap_0
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_trigger_in[13] -to "emu:emu|dataController_top:dc0|ncr5380:scsi|rdata[7]" -section_id auto_signaltap_0
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_trigger_in[14] -to "emu:emu|dataController_top:dc0|ncr5380:scsi|scsi:scsi2|ack" -section_id auto_signaltap_0
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_trigger_in[15] -to "emu:emu|dataController_top:dc0|ncr5380:scsi|scsi:scsi2|atn" -section_id auto_signaltap_0
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_trigger_in[16] -to "emu:emu|dataController_top:dc0|ncr5380:scsi|scsi:scsi2|bsy" -section_id auto_signaltap_0
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_trigger_in[17] -to "emu:emu|dataController_top:dc0|ncr5380:scsi|scsi:scsi2|cd" -section_id auto_signaltap_0
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_trigger_in[18] -to "emu:emu|dataController_top:dc0|ncr5380:scsi|scsi:scsi2|io" -section_id auto_signaltap_0
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_trigger_in[19] -to "emu:emu|dataController_top:dc0|ncr5380:scsi|scsi:scsi2|req" -section_id auto_signaltap_0
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_data_in[1] -to "emu:emu|dataController_top:dc0|ncr5380:scsi|bus_cs" -section_id auto_signaltap_0
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_data_in[2] -to "emu:emu|dataController_top:dc0|ncr5380:scsi|bus_rs[0]" -section_id auto_signaltap_0
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_data_in[3] -to "emu:emu|dataController_top:dc0|ncr5380:scsi|bus_rs[1]" -section_id auto_signaltap_0
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_data_in[4] -to "emu:emu|dataController_top:dc0|ncr5380:scsi|bus_rs[2]" -section_id auto_signaltap_0
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_data_in[5] -to "emu:emu|dataController_top:dc0|ncr5380:scsi|bus_we" -section_id auto_signaltap_0
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_data_in[6] -to "emu:emu|dataController_top:dc0|ncr5380:scsi|rdata[0]" -section_id auto_signaltap_0
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_data_in[7] -to "emu:emu|dataController_top:dc0|ncr5380:scsi|rdata[1]" -section_id auto_signaltap_0
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_data_in[8] -to "emu:emu|dataController_top:dc0|ncr5380:scsi|rdata[2]" -section_id auto_signaltap_0
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_data_in[9] -to "emu:emu|dataController_top:dc0|ncr5380:scsi|rdata[3]" -section_id auto_signaltap_0
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_data_in[10] -to "emu:emu|dataController_top:dc0|ncr5380:scsi|rdata[4]" -section_id auto_signaltap_0
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_data_in[11] -to "emu:emu|dataController_top:dc0|ncr5380:scsi|rdata[5]" -section_id auto_signaltap_0
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_data_in[12] -to "emu:emu|dataController_top:dc0|ncr5380:scsi|rdata[6]" -section_id auto_signaltap_0
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_data_in[13] -to "emu:emu|dataController_top:dc0|ncr5380:scsi|rdata[7]" -section_id auto_signaltap_0
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_data_in[14] -to "emu:emu|dataController_top:dc0|ncr5380:scsi|scsi:scsi2|ack" -section_id auto_signaltap_0
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_data_in[15] -to "emu:emu|dataController_top:dc0|ncr5380:scsi|scsi:scsi2|atn" -section_id auto_signaltap_0
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_data_in[16] -to "emu:emu|dataController_top:dc0|ncr5380:scsi|scsi:scsi2|bsy" -section_id auto_signaltap_0
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_data_in[17] -to "emu:emu|dataController_top:dc0|ncr5380:scsi|scsi:scsi2|cd" -section_id auto_signaltap_0
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_data_in[18] -to "emu:emu|dataController_top:dc0|ncr5380:scsi|scsi:scsi2|io" -section_id auto_signaltap_0
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_data_in[19] -to "emu:emu|dataController_top:dc0|ncr5380:scsi|scsi:scsi2|req" -section_id auto_signaltap_0
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_storage_qualifier_in[1] -to "emu:emu|dataController_top:dc0|ncr5380:scsi|bus_cs" -section_id auto_signaltap_0
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_storage_qualifier_in[2] -to "emu:emu|dataController_top:dc0|ncr5380:scsi|bus_rs[0]" -section_id auto_signaltap_0
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_storage_qualifier_in[3] -to "emu:emu|dataController_top:dc0|ncr5380:scsi|bus_rs[1]" -section_id auto_signaltap_0
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_storage_qualifier_in[4] -to "emu:emu|dataController_top:dc0|ncr5380:scsi|bus_rs[2]" -section_id auto_signaltap_0
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_storage_qualifier_in[5] -to "emu:emu|dataController_top:dc0|ncr5380:scsi|bus_we" -section_id auto_signaltap_0
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_storage_qualifier_in[6] -to "emu:emu|dataController_top:dc0|ncr5380:scsi|rdata[0]" -section_id auto_signaltap_0
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_storage_qualifier_in[7] -to "emu:emu|dataController_top:dc0|ncr5380:scsi|rdata[1]" -section_id auto_signaltap_0
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_storage_qualifier_in[8] -to "emu:emu|dataController_top:dc0|ncr5380:scsi|rdata[2]" -section_id auto_signaltap_0
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_storage_qualifier_in[9] -to "emu:emu|dataController_top:dc0|ncr5380:scsi|rdata[3]" -section_id auto_signaltap_0
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_storage_qualifier_in[10] -to "emu:emu|dataController_top:dc0|ncr5380:scsi|rdata[4]" -section_id auto_signaltap_0
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_storage_qualifier_in[11] -to "emu:emu|dataController_top:dc0|ncr5380:scsi|rdata[5]" -section_id auto_signaltap_0
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_storage_qualifier_in[12] -to "emu:emu|dataController_top:dc0|ncr5380:scsi|rdata[6]" -section_id auto_signaltap_0
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_storage_qualifier_in[13] -to "emu:emu|dataController_top:dc0|ncr5380:scsi|rdata[7]" -section_id auto_signaltap_0
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_storage_qualifier_in[14] -to "emu:emu|dataController_top:dc0|ncr5380:scsi|scsi:scsi2|ack" -section_id auto_signaltap_0
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_storage_qualifier_in[15] -to "emu:emu|dataController_top:dc0|ncr5380:scsi|scsi:scsi2|atn" -section_id auto_signaltap_0
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_storage_qualifier_in[16] -to "emu:emu|dataController_top:dc0|ncr5380:scsi|scsi:scsi2|bsy" -section_id auto_signaltap_0
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_storage_qualifier_in[17] -to "emu:emu|dataController_top:dc0|ncr5380:scsi|scsi:scsi2|cd" -section_id auto_signaltap_0
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_storage_qualifier_in[18] -to "emu:emu|dataController_top:dc0|ncr5380:scsi|scsi:scsi2|io" -section_id auto_signaltap_0
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_storage_qualifier_in[19] -to "emu:emu|dataController_top:dc0|ncr5380:scsi|scsi:scsi2|req" -section_id auto_signaltap_0
+set_instance_assignment -name POST_FIT_CONNECT_TO_SLD_NODE_ENTITY_PORT crc[6] -to auto_signaltap_0|gnd -section_id auto_signaltap_0
+set_instance_assignment -name POST_FIT_CONNECT_TO_SLD_NODE_ENTITY_PORT crc[19] -to auto_signaltap_0|vcc -section_id auto_signaltap_0
+set_instance_assignment -name POST_FIT_CONNECT_TO_SLD_NODE_ENTITY_PORT crc[3] -to auto_signaltap_0|gnd -section_id auto_signaltap_0
+set_instance_assignment -name POST_FIT_CONNECT_TO_SLD_NODE_ENTITY_PORT crc[8] -to auto_signaltap_0|gnd -section_id auto_signaltap_0
+set_instance_assignment -name POST_FIT_CONNECT_TO_SLD_NODE_ENTITY_PORT crc[9] -to auto_signaltap_0|gnd -section_id auto_signaltap_0
+set_instance_assignment -name POST_FIT_CONNECT_TO_SLD_NODE_ENTITY_PORT crc[11] -to auto_signaltap_0|gnd -section_id auto_signaltap_0
+set_instance_assignment -name POST_FIT_CONNECT_TO_SLD_NODE_ENTITY_PORT crc[13] -to auto_signaltap_0|gnd -section_id auto_signaltap_0
+set_instance_assignment -name POST_FIT_CONNECT_TO_SLD_NODE_ENTITY_PORT crc[26] -to auto_signaltap_0|gnd -section_id auto_signaltap_0
+set_instance_assignment -name POST_FIT_CONNECT_TO_SLD_NODE_ENTITY_PORT crc[30] -to auto_signaltap_0|vcc -section_id auto_signaltap_0
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_trigger_in[20] -to "emu:emu|dataController_top:dc0|ncr5380:scsi|scsi:scsi2|sd_buff_wr" -section_id auto_signaltap_0
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_trigger_in[21] -to "emu:emu|dataController_top:dc0|ncr5380:scsi|scsi:scsi2|sel" -section_id auto_signaltap_0
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_trigger_in[22] -to "emu:emu|dataController_top:dc0|ncr5380:scsi|scsi:scsi6|ack" -section_id auto_signaltap_0
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_trigger_in[23] -to "emu:emu|dataController_top:dc0|ncr5380:scsi|scsi:scsi6|atn" -section_id auto_signaltap_0
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_trigger_in[24] -to "emu:emu|dataController_top:dc0|ncr5380:scsi|scsi:scsi6|bsy" -section_id auto_signaltap_0
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_trigger_in[25] -to "emu:emu|dataController_top:dc0|ncr5380:scsi|scsi:scsi6|cd" -section_id auto_signaltap_0
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_trigger_in[26] -to "emu:emu|dataController_top:dc0|ncr5380:scsi|scsi:scsi6|io" -section_id auto_signaltap_0
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_trigger_in[27] -to "emu:emu|dataController_top:dc0|ncr5380:scsi|scsi:scsi6|req" -section_id auto_signaltap_0
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_trigger_in[28] -to "emu:emu|dataController_top:dc0|ncr5380:scsi|scsi:scsi6|sd_buff_wr" -section_id auto_signaltap_0
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_trigger_in[29] -to "emu:emu|dataController_top:dc0|ncr5380:scsi|scsi:scsi6|sel" -section_id auto_signaltap_0
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_trigger_in[30] -to "emu:emu|dataController_top:dc0|ncr5380:scsi|wdata[0]" -section_id auto_signaltap_0
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_trigger_in[31] -to "emu:emu|dataController_top:dc0|ncr5380:scsi|wdata[1]" -section_id auto_signaltap_0
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_trigger_in[32] -to "emu:emu|dataController_top:dc0|ncr5380:scsi|wdata[2]" -section_id auto_signaltap_0
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_trigger_in[33] -to "emu:emu|dataController_top:dc0|ncr5380:scsi|wdata[3]" -section_id auto_signaltap_0
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_trigger_in[34] -to "emu:emu|dataController_top:dc0|ncr5380:scsi|wdata[4]" -section_id auto_signaltap_0
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_trigger_in[35] -to "emu:emu|dataController_top:dc0|ncr5380:scsi|wdata[5]" -section_id auto_signaltap_0
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_trigger_in[36] -to "emu:emu|dataController_top:dc0|ncr5380:scsi|wdata[6]" -section_id auto_signaltap_0
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_trigger_in[37] -to "emu:emu|dataController_top:dc0|ncr5380:scsi|wdata[7]" -section_id auto_signaltap_0
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_trigger_in[38] -to "emu:emu|hps_io:hps_io|sd_ack" -section_id auto_signaltap_0
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_trigger_in[39] -to "emu:emu|hps_io:hps_io|sd_buff_addr[0]" -section_id auto_signaltap_0
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_trigger_in[40] -to "emu:emu|hps_io:hps_io|sd_buff_addr[1]" -section_id auto_signaltap_0
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_trigger_in[41] -to "emu:emu|hps_io:hps_io|sd_buff_addr[2]" -section_id auto_signaltap_0
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_trigger_in[42] -to "emu:emu|hps_io:hps_io|sd_buff_addr[3]" -section_id auto_signaltap_0
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_trigger_in[43] -to "emu:emu|hps_io:hps_io|sd_buff_addr[4]" -section_id auto_signaltap_0
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_trigger_in[44] -to "emu:emu|hps_io:hps_io|sd_buff_addr[5]" -section_id auto_signaltap_0
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_trigger_in[45] -to "emu:emu|hps_io:hps_io|sd_buff_addr[6]" -section_id auto_signaltap_0
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_trigger_in[46] -to "emu:emu|hps_io:hps_io|sd_buff_addr[7]" -section_id auto_signaltap_0
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_trigger_in[47] -to "emu:emu|hps_io:hps_io|sd_buff_addr[8]" -section_id auto_signaltap_0
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_trigger_in[48] -to "emu:emu|hps_io:hps_io|sd_buff_dout[0]" -section_id auto_signaltap_0
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_trigger_in[49] -to "emu:emu|hps_io:hps_io|sd_buff_dout[1]" -section_id auto_signaltap_0
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_trigger_in[50] -to "emu:emu|hps_io:hps_io|sd_buff_dout[2]" -section_id auto_signaltap_0
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_trigger_in[51] -to "emu:emu|hps_io:hps_io|sd_buff_dout[3]" -section_id auto_signaltap_0
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_trigger_in[52] -to "emu:emu|hps_io:hps_io|sd_buff_dout[4]" -section_id auto_signaltap_0
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_trigger_in[53] -to "emu:emu|hps_io:hps_io|sd_buff_dout[5]" -section_id auto_signaltap_0
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_trigger_in[54] -to "emu:emu|hps_io:hps_io|sd_buff_dout[6]" -section_id auto_signaltap_0
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_trigger_in[55] -to "emu:emu|hps_io:hps_io|sd_buff_dout[7]" -section_id auto_signaltap_0
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_trigger_in[56] -to "emu:emu|hps_io:hps_io|sd_lba[0]" -section_id auto_signaltap_0
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_trigger_in[57] -to "emu:emu|hps_io:hps_io|sd_lba[10]" -section_id auto_signaltap_0
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_trigger_in[58] -to "emu:emu|hps_io:hps_io|sd_lba[11]" -section_id auto_signaltap_0
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_trigger_in[59] -to "emu:emu|hps_io:hps_io|sd_lba[12]" -section_id auto_signaltap_0
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_trigger_in[60] -to "emu:emu|hps_io:hps_io|sd_lba[13]" -section_id auto_signaltap_0
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_trigger_in[61] -to "emu:emu|hps_io:hps_io|sd_lba[14]" -section_id auto_signaltap_0
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_trigger_in[62] -to "emu:emu|hps_io:hps_io|sd_lba[15]" -section_id auto_signaltap_0
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_trigger_in[63] -to "emu:emu|hps_io:hps_io|sd_lba[16]" -section_id auto_signaltap_0
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_trigger_in[64] -to "emu:emu|hps_io:hps_io|sd_lba[17]" -section_id auto_signaltap_0
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_trigger_in[65] -to "emu:emu|hps_io:hps_io|sd_lba[18]" -section_id auto_signaltap_0
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_trigger_in[66] -to "emu:emu|hps_io:hps_io|sd_lba[19]" -section_id auto_signaltap_0
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_trigger_in[67] -to "emu:emu|hps_io:hps_io|sd_lba[1]" -section_id auto_signaltap_0
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_trigger_in[68] -to "emu:emu|hps_io:hps_io|sd_lba[20]" -section_id auto_signaltap_0
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_trigger_in[69] -to "emu:emu|hps_io:hps_io|sd_lba[21]" -section_id auto_signaltap_0
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_trigger_in[70] -to "emu:emu|hps_io:hps_io|sd_lba[22]" -section_id auto_signaltap_0
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_trigger_in[71] -to "emu:emu|hps_io:hps_io|sd_lba[23]" -section_id auto_signaltap_0
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_trigger_in[72] -to "emu:emu|hps_io:hps_io|sd_lba[24]" -section_id auto_signaltap_0
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_trigger_in[73] -to "emu:emu|hps_io:hps_io|sd_lba[25]" -section_id auto_signaltap_0
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_trigger_in[74] -to "emu:emu|hps_io:hps_io|sd_lba[26]" -section_id auto_signaltap_0
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_trigger_in[75] -to "emu:emu|hps_io:hps_io|sd_lba[27]" -section_id auto_signaltap_0
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_trigger_in[76] -to "emu:emu|hps_io:hps_io|sd_lba[28]" -section_id auto_signaltap_0
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_trigger_in[77] -to "emu:emu|hps_io:hps_io|sd_lba[29]" -section_id auto_signaltap_0
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_trigger_in[78] -to "emu:emu|hps_io:hps_io|sd_lba[2]" -section_id auto_signaltap_0
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_trigger_in[79] -to "emu:emu|hps_io:hps_io|sd_lba[30]" -section_id auto_signaltap_0
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_trigger_in[80] -to "emu:emu|hps_io:hps_io|sd_lba[31]" -section_id auto_signaltap_0
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_trigger_in[81] -to "emu:emu|hps_io:hps_io|sd_lba[3]" -section_id auto_signaltap_0
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_trigger_in[82] -to "emu:emu|hps_io:hps_io|sd_lba[4]" -section_id auto_signaltap_0
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_trigger_in[83] -to "emu:emu|hps_io:hps_io|sd_lba[5]" -section_id auto_signaltap_0
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_trigger_in[84] -to "emu:emu|hps_io:hps_io|sd_lba[6]" -section_id auto_signaltap_0
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_trigger_in[85] -to "emu:emu|hps_io:hps_io|sd_lba[7]" -section_id auto_signaltap_0
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_trigger_in[86] -to "emu:emu|hps_io:hps_io|sd_lba[8]" -section_id auto_signaltap_0
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_trigger_in[87] -to "emu:emu|hps_io:hps_io|sd_lba[9]" -section_id auto_signaltap_0
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_trigger_in[88] -to "emu:emu|hps_io:hps_io|sd_rd[0]" -section_id auto_signaltap_0
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_trigger_in[89] -to "emu:emu|hps_io:hps_io|sd_rd[1]" -section_id auto_signaltap_0
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_trigger_in[90] -to "emu:emu|hps_io:hps_io|sd_wr[0]" -section_id auto_signaltap_0
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_trigger_in[91] -to "emu:emu|hps_io:hps_io|sd_wr[1]" -section_id auto_signaltap_0
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_data_in[20] -to "emu:emu|dataController_top:dc0|ncr5380:scsi|scsi:scsi2|sd_buff_wr" -section_id auto_signaltap_0
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_data_in[21] -to "emu:emu|dataController_top:dc0|ncr5380:scsi|scsi:scsi2|sel" -section_id auto_signaltap_0
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_data_in[22] -to "emu:emu|dataController_top:dc0|ncr5380:scsi|scsi:scsi6|ack" -section_id auto_signaltap_0
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_data_in[23] -to "emu:emu|dataController_top:dc0|ncr5380:scsi|scsi:scsi6|atn" -section_id auto_signaltap_0
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_data_in[24] -to "emu:emu|dataController_top:dc0|ncr5380:scsi|scsi:scsi6|bsy" -section_id auto_signaltap_0
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_data_in[25] -to "emu:emu|dataController_top:dc0|ncr5380:scsi|scsi:scsi6|cd" -section_id auto_signaltap_0
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_data_in[26] -to "emu:emu|dataController_top:dc0|ncr5380:scsi|scsi:scsi6|io" -section_id auto_signaltap_0
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_data_in[27] -to "emu:emu|dataController_top:dc0|ncr5380:scsi|scsi:scsi6|req" -section_id auto_signaltap_0
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_data_in[28] -to "emu:emu|dataController_top:dc0|ncr5380:scsi|scsi:scsi6|sd_buff_wr" -section_id auto_signaltap_0
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_data_in[29] -to "emu:emu|dataController_top:dc0|ncr5380:scsi|scsi:scsi6|sel" -section_id auto_signaltap_0
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_data_in[30] -to "emu:emu|dataController_top:dc0|ncr5380:scsi|wdata[0]" -section_id auto_signaltap_0
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_data_in[31] -to "emu:emu|dataController_top:dc0|ncr5380:scsi|wdata[1]" -section_id auto_signaltap_0
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_data_in[32] -to "emu:emu|dataController_top:dc0|ncr5380:scsi|wdata[2]" -section_id auto_signaltap_0
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_data_in[33] -to "emu:emu|dataController_top:dc0|ncr5380:scsi|wdata[3]" -section_id auto_signaltap_0
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_data_in[34] -to "emu:emu|dataController_top:dc0|ncr5380:scsi|wdata[4]" -section_id auto_signaltap_0
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_data_in[35] -to "emu:emu|dataController_top:dc0|ncr5380:scsi|wdata[5]" -section_id auto_signaltap_0
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_data_in[36] -to "emu:emu|dataController_top:dc0|ncr5380:scsi|wdata[6]" -section_id auto_signaltap_0
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_data_in[37] -to "emu:emu|dataController_top:dc0|ncr5380:scsi|wdata[7]" -section_id auto_signaltap_0
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_data_in[38] -to "emu:emu|hps_io:hps_io|sd_ack" -section_id auto_signaltap_0
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_data_in[39] -to "emu:emu|hps_io:hps_io|sd_buff_addr[0]" -section_id auto_signaltap_0
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_data_in[40] -to "emu:emu|hps_io:hps_io|sd_buff_addr[1]" -section_id auto_signaltap_0
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_data_in[41] -to "emu:emu|hps_io:hps_io|sd_buff_addr[2]" -section_id auto_signaltap_0
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_data_in[42] -to "emu:emu|hps_io:hps_io|sd_buff_addr[3]" -section_id auto_signaltap_0
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_data_in[43] -to "emu:emu|hps_io:hps_io|sd_buff_addr[4]" -section_id auto_signaltap_0
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_data_in[44] -to "emu:emu|hps_io:hps_io|sd_buff_addr[5]" -section_id auto_signaltap_0
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_data_in[45] -to "emu:emu|hps_io:hps_io|sd_buff_addr[6]" -section_id auto_signaltap_0
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_data_in[46] -to "emu:emu|hps_io:hps_io|sd_buff_addr[7]" -section_id auto_signaltap_0
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_data_in[47] -to "emu:emu|hps_io:hps_io|sd_buff_addr[8]" -section_id auto_signaltap_0
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_data_in[48] -to "emu:emu|hps_io:hps_io|sd_buff_dout[0]" -section_id auto_signaltap_0
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_data_in[49] -to "emu:emu|hps_io:hps_io|sd_buff_dout[1]" -section_id auto_signaltap_0
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_data_in[50] -to "emu:emu|hps_io:hps_io|sd_buff_dout[2]" -section_id auto_signaltap_0
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_data_in[51] -to "emu:emu|hps_io:hps_io|sd_buff_dout[3]" -section_id auto_signaltap_0
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_data_in[52] -to "emu:emu|hps_io:hps_io|sd_buff_dout[4]" -section_id auto_signaltap_0
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_data_in[53] -to "emu:emu|hps_io:hps_io|sd_buff_dout[5]" -section_id auto_signaltap_0
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_data_in[54] -to "emu:emu|hps_io:hps_io|sd_buff_dout[6]" -section_id auto_signaltap_0
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_data_in[55] -to "emu:emu|hps_io:hps_io|sd_buff_dout[7]" -section_id auto_signaltap_0
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_data_in[56] -to "emu:emu|hps_io:hps_io|sd_lba[0]" -section_id auto_signaltap_0
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_data_in[57] -to "emu:emu|hps_io:hps_io|sd_lba[10]" -section_id auto_signaltap_0
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_data_in[58] -to "emu:emu|hps_io:hps_io|sd_lba[11]" -section_id auto_signaltap_0
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_data_in[59] -to "emu:emu|hps_io:hps_io|sd_lba[12]" -section_id auto_signaltap_0
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_data_in[60] -to "emu:emu|hps_io:hps_io|sd_lba[13]" -section_id auto_signaltap_0
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_data_in[61] -to "emu:emu|hps_io:hps_io|sd_lba[14]" -section_id auto_signaltap_0
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_data_in[62] -to "emu:emu|hps_io:hps_io|sd_lba[15]" -section_id auto_signaltap_0
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_data_in[63] -to "emu:emu|hps_io:hps_io|sd_lba[16]" -section_id auto_signaltap_0
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_data_in[64] -to "emu:emu|hps_io:hps_io|sd_lba[17]" -section_id auto_signaltap_0
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_data_in[65] -to "emu:emu|hps_io:hps_io|sd_lba[18]" -section_id auto_signaltap_0
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_data_in[66] -to "emu:emu|hps_io:hps_io|sd_lba[19]" -section_id auto_signaltap_0
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_data_in[67] -to "emu:emu|hps_io:hps_io|sd_lba[1]" -section_id auto_signaltap_0
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_data_in[68] -to "emu:emu|hps_io:hps_io|sd_lba[20]" -section_id auto_signaltap_0
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_data_in[69] -to "emu:emu|hps_io:hps_io|sd_lba[21]" -section_id auto_signaltap_0
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_data_in[70] -to "emu:emu|hps_io:hps_io|sd_lba[22]" -section_id auto_signaltap_0
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_data_in[71] -to "emu:emu|hps_io:hps_io|sd_lba[23]" -section_id auto_signaltap_0
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_data_in[72] -to "emu:emu|hps_io:hps_io|sd_lba[24]" -section_id auto_signaltap_0
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_data_in[73] -to "emu:emu|hps_io:hps_io|sd_lba[25]" -section_id auto_signaltap_0
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_data_in[74] -to "emu:emu|hps_io:hps_io|sd_lba[26]" -section_id auto_signaltap_0
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_data_in[75] -to "emu:emu|hps_io:hps_io|sd_lba[27]" -section_id auto_signaltap_0
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_data_in[76] -to "emu:emu|hps_io:hps_io|sd_lba[28]" -section_id auto_signaltap_0
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_data_in[77] -to "emu:emu|hps_io:hps_io|sd_lba[29]" -section_id auto_signaltap_0
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_data_in[78] -to "emu:emu|hps_io:hps_io|sd_lba[2]" -section_id auto_signaltap_0
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_data_in[79] -to "emu:emu|hps_io:hps_io|sd_lba[30]" -section_id auto_signaltap_0
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_data_in[80] -to "emu:emu|hps_io:hps_io|sd_lba[31]" -section_id auto_signaltap_0
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_data_in[81] -to "emu:emu|hps_io:hps_io|sd_lba[3]" -section_id auto_signaltap_0
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_data_in[82] -to "emu:emu|hps_io:hps_io|sd_lba[4]" -section_id auto_signaltap_0
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_data_in[83] -to "emu:emu|hps_io:hps_io|sd_lba[5]" -section_id auto_signaltap_0
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_data_in[84] -to "emu:emu|hps_io:hps_io|sd_lba[6]" -section_id auto_signaltap_0
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_data_in[85] -to "emu:emu|hps_io:hps_io|sd_lba[7]" -section_id auto_signaltap_0
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_data_in[86] -to "emu:emu|hps_io:hps_io|sd_lba[8]" -section_id auto_signaltap_0
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_data_in[87] -to "emu:emu|hps_io:hps_io|sd_lba[9]" -section_id auto_signaltap_0
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_data_in[88] -to "emu:emu|hps_io:hps_io|sd_rd[0]" -section_id auto_signaltap_0
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_data_in[89] -to "emu:emu|hps_io:hps_io|sd_rd[1]" -section_id auto_signaltap_0
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_data_in[90] -to "emu:emu|hps_io:hps_io|sd_wr[0]" -section_id auto_signaltap_0
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_data_in[91] -to "emu:emu|hps_io:hps_io|sd_wr[1]" -section_id auto_signaltap_0
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_storage_qualifier_in[20] -to "emu:emu|dataController_top:dc0|ncr5380:scsi|scsi:scsi2|sd_buff_wr" -section_id auto_signaltap_0
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_storage_qualifier_in[21] -to "emu:emu|dataController_top:dc0|ncr5380:scsi|scsi:scsi2|sel" -section_id auto_signaltap_0
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_storage_qualifier_in[22] -to "emu:emu|dataController_top:dc0|ncr5380:scsi|scsi:scsi6|ack" -section_id auto_signaltap_0
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_storage_qualifier_in[23] -to "emu:emu|dataController_top:dc0|ncr5380:scsi|scsi:scsi6|atn" -section_id auto_signaltap_0
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_storage_qualifier_in[24] -to "emu:emu|dataController_top:dc0|ncr5380:scsi|scsi:scsi6|bsy" -section_id auto_signaltap_0
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_storage_qualifier_in[25] -to "emu:emu|dataController_top:dc0|ncr5380:scsi|scsi:scsi6|cd" -section_id auto_signaltap_0
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_storage_qualifier_in[26] -to "emu:emu|dataController_top:dc0|ncr5380:scsi|scsi:scsi6|io" -section_id auto_signaltap_0
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_storage_qualifier_in[27] -to "emu:emu|dataController_top:dc0|ncr5380:scsi|scsi:scsi6|req" -section_id auto_signaltap_0
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_storage_qualifier_in[28] -to "emu:emu|dataController_top:dc0|ncr5380:scsi|scsi:scsi6|sd_buff_wr" -section_id auto_signaltap_0
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_storage_qualifier_in[29] -to "emu:emu|dataController_top:dc0|ncr5380:scsi|scsi:scsi6|sel" -section_id auto_signaltap_0
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_storage_qualifier_in[30] -to "emu:emu|dataController_top:dc0|ncr5380:scsi|wdata[0]" -section_id auto_signaltap_0
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_storage_qualifier_in[31] -to "emu:emu|dataController_top:dc0|ncr5380:scsi|wdata[1]" -section_id auto_signaltap_0
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_storage_qualifier_in[32] -to "emu:emu|dataController_top:dc0|ncr5380:scsi|wdata[2]" -section_id auto_signaltap_0
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_storage_qualifier_in[33] -to "emu:emu|dataController_top:dc0|ncr5380:scsi|wdata[3]" -section_id auto_signaltap_0
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_storage_qualifier_in[34] -to "emu:emu|dataController_top:dc0|ncr5380:scsi|wdata[4]" -section_id auto_signaltap_0
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_storage_qualifier_in[35] -to "emu:emu|dataController_top:dc0|ncr5380:scsi|wdata[5]" -section_id auto_signaltap_0
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_storage_qualifier_in[36] -to "emu:emu|dataController_top:dc0|ncr5380:scsi|wdata[6]" -section_id auto_signaltap_0
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_storage_qualifier_in[37] -to "emu:emu|dataController_top:dc0|ncr5380:scsi|wdata[7]" -section_id auto_signaltap_0
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_storage_qualifier_in[38] -to "emu:emu|hps_io:hps_io|sd_ack" -section_id auto_signaltap_0
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_storage_qualifier_in[39] -to "emu:emu|hps_io:hps_io|sd_buff_addr[0]" -section_id auto_signaltap_0
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_storage_qualifier_in[40] -to "emu:emu|hps_io:hps_io|sd_buff_addr[1]" -section_id auto_signaltap_0
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_storage_qualifier_in[41] -to "emu:emu|hps_io:hps_io|sd_buff_addr[2]" -section_id auto_signaltap_0
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_storage_qualifier_in[42] -to "emu:emu|hps_io:hps_io|sd_buff_addr[3]" -section_id auto_signaltap_0
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_storage_qualifier_in[43] -to "emu:emu|hps_io:hps_io|sd_buff_addr[4]" -section_id auto_signaltap_0
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_storage_qualifier_in[44] -to "emu:emu|hps_io:hps_io|sd_buff_addr[5]" -section_id auto_signaltap_0
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_storage_qualifier_in[45] -to "emu:emu|hps_io:hps_io|sd_buff_addr[6]" -section_id auto_signaltap_0
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_storage_qualifier_in[46] -to "emu:emu|hps_io:hps_io|sd_buff_addr[7]" -section_id auto_signaltap_0
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_storage_qualifier_in[47] -to "emu:emu|hps_io:hps_io|sd_buff_addr[8]" -section_id auto_signaltap_0
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_storage_qualifier_in[48] -to "emu:emu|hps_io:hps_io|sd_buff_dout[0]" -section_id auto_signaltap_0
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_storage_qualifier_in[49] -to "emu:emu|hps_io:hps_io|sd_buff_dout[1]" -section_id auto_signaltap_0
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_storage_qualifier_in[50] -to "emu:emu|hps_io:hps_io|sd_buff_dout[2]" -section_id auto_signaltap_0
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_storage_qualifier_in[51] -to "emu:emu|hps_io:hps_io|sd_buff_dout[3]" -section_id auto_signaltap_0
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_storage_qualifier_in[52] -to "emu:emu|hps_io:hps_io|sd_buff_dout[4]" -section_id auto_signaltap_0
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_storage_qualifier_in[53] -to "emu:emu|hps_io:hps_io|sd_buff_dout[5]" -section_id auto_signaltap_0
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_storage_qualifier_in[54] -to "emu:emu|hps_io:hps_io|sd_buff_dout[6]" -section_id auto_signaltap_0
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_storage_qualifier_in[55] -to "emu:emu|hps_io:hps_io|sd_buff_dout[7]" -section_id auto_signaltap_0
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_storage_qualifier_in[56] -to "emu:emu|hps_io:hps_io|sd_lba[0]" -section_id auto_signaltap_0
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_storage_qualifier_in[57] -to "emu:emu|hps_io:hps_io|sd_lba[10]" -section_id auto_signaltap_0
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_storage_qualifier_in[58] -to "emu:emu|hps_io:hps_io|sd_lba[11]" -section_id auto_signaltap_0
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_storage_qualifier_in[59] -to "emu:emu|hps_io:hps_io|sd_lba[12]" -section_id auto_signaltap_0
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_storage_qualifier_in[60] -to "emu:emu|hps_io:hps_io|sd_lba[13]" -section_id auto_signaltap_0
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_storage_qualifier_in[61] -to "emu:emu|hps_io:hps_io|sd_lba[14]" -section_id auto_signaltap_0
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_storage_qualifier_in[62] -to "emu:emu|hps_io:hps_io|sd_lba[15]" -section_id auto_signaltap_0
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_storage_qualifier_in[63] -to "emu:emu|hps_io:hps_io|sd_lba[16]" -section_id auto_signaltap_0
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_storage_qualifier_in[64] -to "emu:emu|hps_io:hps_io|sd_lba[17]" -section_id auto_signaltap_0
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_storage_qualifier_in[65] -to "emu:emu|hps_io:hps_io|sd_lba[18]" -section_id auto_signaltap_0
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_storage_qualifier_in[66] -to "emu:emu|hps_io:hps_io|sd_lba[19]" -section_id auto_signaltap_0
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_storage_qualifier_in[67] -to "emu:emu|hps_io:hps_io|sd_lba[1]" -section_id auto_signaltap_0
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_storage_qualifier_in[68] -to "emu:emu|hps_io:hps_io|sd_lba[20]" -section_id auto_signaltap_0
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_storage_qualifier_in[69] -to "emu:emu|hps_io:hps_io|sd_lba[21]" -section_id auto_signaltap_0
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_storage_qualifier_in[70] -to "emu:emu|hps_io:hps_io|sd_lba[22]" -section_id auto_signaltap_0
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_storage_qualifier_in[71] -to "emu:emu|hps_io:hps_io|sd_lba[23]" -section_id auto_signaltap_0
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_storage_qualifier_in[72] -to "emu:emu|hps_io:hps_io|sd_lba[24]" -section_id auto_signaltap_0
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_storage_qualifier_in[73] -to "emu:emu|hps_io:hps_io|sd_lba[25]" -section_id auto_signaltap_0
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_storage_qualifier_in[74] -to "emu:emu|hps_io:hps_io|sd_lba[26]" -section_id auto_signaltap_0
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_storage_qualifier_in[75] -to "emu:emu|hps_io:hps_io|sd_lba[27]" -section_id auto_signaltap_0
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_storage_qualifier_in[76] -to "emu:emu|hps_io:hps_io|sd_lba[28]" -section_id auto_signaltap_0
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_storage_qualifier_in[77] -to "emu:emu|hps_io:hps_io|sd_lba[29]" -section_id auto_signaltap_0
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_storage_qualifier_in[78] -to "emu:emu|hps_io:hps_io|sd_lba[2]" -section_id auto_signaltap_0
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_storage_qualifier_in[79] -to "emu:emu|hps_io:hps_io|sd_lba[30]" -section_id auto_signaltap_0
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_storage_qualifier_in[80] -to "emu:emu|hps_io:hps_io|sd_lba[31]" -section_id auto_signaltap_0
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_storage_qualifier_in[81] -to "emu:emu|hps_io:hps_io|sd_lba[3]" -section_id auto_signaltap_0
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_storage_qualifier_in[82] -to "emu:emu|hps_io:hps_io|sd_lba[4]" -section_id auto_signaltap_0
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_storage_qualifier_in[83] -to "emu:emu|hps_io:hps_io|sd_lba[5]" -section_id auto_signaltap_0
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_storage_qualifier_in[84] -to "emu:emu|hps_io:hps_io|sd_lba[6]" -section_id auto_signaltap_0
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_storage_qualifier_in[85] -to "emu:emu|hps_io:hps_io|sd_lba[7]" -section_id auto_signaltap_0
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_storage_qualifier_in[86] -to "emu:emu|hps_io:hps_io|sd_lba[8]" -section_id auto_signaltap_0
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_storage_qualifier_in[87] -to "emu:emu|hps_io:hps_io|sd_lba[9]" -section_id auto_signaltap_0
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_storage_qualifier_in[88] -to "emu:emu|hps_io:hps_io|sd_rd[0]" -section_id auto_signaltap_0
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_storage_qualifier_in[89] -to "emu:emu|hps_io:hps_io|sd_rd[1]" -section_id auto_signaltap_0
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_storage_qualifier_in[90] -to "emu:emu|hps_io:hps_io|sd_wr[0]" -section_id auto_signaltap_0
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_storage_qualifier_in[91] -to "emu:emu|hps_io:hps_io|sd_wr[1]" -section_id auto_signaltap_0
+set_global_assignment -name SLD_NODE_PARAMETER_ASSIGNMENT "SLD_DATA_BITS=92" -section_id auto_signaltap_0
+set_global_assignment -name SLD_NODE_PARAMETER_ASSIGNMENT "SLD_TRIGGER_BITS=92" -section_id auto_signaltap_0
+set_global_assignment -name SLD_NODE_PARAMETER_ASSIGNMENT "SLD_STORAGE_QUALIFIER_BITS=92" -section_id auto_signaltap_0
+set_global_assignment -name SLD_NODE_PARAMETER_ASSIGNMENT "SLD_INVERSION_MASK=00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000" -section_id auto_signaltap_0
+set_global_assignment -name SLD_NODE_PARAMETER_ASSIGNMENT "SLD_INVERSION_MASK_LENGTH=578" -section_id auto_signaltap_0
+set_global_assignment -name SLD_NODE_PARAMETER_ASSIGNMENT "SLD_STORAGE_QUALIFIER_INVERSION_MASK_LENGTH=277" -section_id auto_signaltap_0
+set_instance_assignment -name POST_FIT_CONNECT_TO_SLD_NODE_ENTITY_PORT crc[5] -to auto_signaltap_0|vcc -section_id auto_signaltap_0
+set_instance_assignment -name POST_FIT_CONNECT_TO_SLD_NODE_ENTITY_PORT crc[7] -to auto_signaltap_0|gnd -section_id auto_signaltap_0
+set_instance_assignment -name POST_FIT_CONNECT_TO_SLD_NODE_ENTITY_PORT crc[17] -to auto_signaltap_0|vcc -section_id auto_signaltap_0
+set_instance_assignment -name POST_FIT_CONNECT_TO_SLD_NODE_ENTITY_PORT crc[25] -to auto_signaltap_0|vcc -section_id auto_signaltap_0
+set_instance_assignment -name POST_FIT_CONNECT_TO_SLD_NODE_ENTITY_PORT crc[29] -to auto_signaltap_0|gnd -section_id auto_signaltap_0
 set_instance_assignment -name PARTITION_HIERARCHY root_partition -to | -section_id Top
+set_global_assignment -name SLD_FILE db/stp1_auto_stripped.stp

--- a/MacPlus.qsf
+++ b/MacPlus.qsf
@@ -397,5 +397,5 @@ set_instance_assignment -name POST_FIT_CONNECT_TO_SLD_NODE_ENTITY_PORT crc[7] -t
 set_instance_assignment -name POST_FIT_CONNECT_TO_SLD_NODE_ENTITY_PORT crc[17] -to auto_signaltap_0|vcc -section_id auto_signaltap_0
 set_instance_assignment -name POST_FIT_CONNECT_TO_SLD_NODE_ENTITY_PORT crc[25] -to auto_signaltap_0|vcc -section_id auto_signaltap_0
 set_instance_assignment -name POST_FIT_CONNECT_TO_SLD_NODE_ENTITY_PORT crc[29] -to auto_signaltap_0|gnd -section_id auto_signaltap_0
-set_instance_assignment -name PARTITION_HIERARCHY root_partition -to | -section_id Top
 set_global_assignment -name SLD_FILE db/stp1_auto_stripped.stp
+set_instance_assignment -name PARTITION_HIERARCHY root_partition -to | -section_id Top

--- a/MacPlus.sv
+++ b/MacPlus.sv
@@ -215,7 +215,7 @@ wire  [1:0] diskMotor, diskAct, diskEject;
 // the status register is controlled by the on screen display (OSD)
 wire [31:0] status;
 wire  [1:0] buttons;
-wire  [2:0] img_mounted;
+wire  [1:0] img_mounted;
 wire [15:0] sd_req_type;
 wire [31:0] sd_lba;
 wire  [1:0] sd_rd;
@@ -314,42 +314,6 @@ TG68KdotC_Kernel #(0,0,0,0,0,0) m68k
 	.nResetOut      ( _cpuResetOut   ),
 	.FC             (                )
 );
-
-/*
-fx68k M68K
-(
-	.clk		( clk_sys ),
-	
-	.extReset( !_cpuReset ),
-	.pwrUp	( !_cpuReset ),
-	
-	.enPhi1	(M68K_CLKENp),
-	.enPhi2	(M68K_CLKENn),
-
-	.eRWn		( _cpuRW ),
-	.ASn		(M68K_AS_N),
-	.UDSn		( _cpuUDS ),
-	.LDSn		( _cpuLDS ),
-
-	.FC0(M68K_FC[0]),
-	.FC1(M68K_FC[1]),
-	.FC2(M68K_FC[2]),
-
-	.BGn(M68K_BG_N),
-	.BRn(M68K_BR_N),
-	.BGACKn(M68K_BGACK_N),
-
-	.DTACKn(M68K_MBUS_DTACK_N),
-	.VPAn(~M68K_INTACK),
-	.BERRn(1),
-	.IPL0n( _cpuIPL[0] ),
-	.IPL1n( _cpuIPL[1] ),
-	.IPL2n( _cpuIPL[2] ),
-	.iEdb( cpuDataIn ),
-	.oEdb( cpuDataOut ),
-	.eab( {cpuAddrHi, cpuAddr} )
-);
-*/
 
 assign VGA_R = {8{pixelOut}};
 assign VGA_G = {8{pixelOut}};

--- a/MacPlus.sv
+++ b/MacPlus.sv
@@ -141,12 +141,13 @@ assign VIDEO_ARY = status[8] ? 8'd9  : 8'd3;
 localparam CONF_STR = {
 	"MACPLUS;;",
 	"-;",
-	"F,DSK;",
-	"F,DSK;",
-	"S,VHD;",
+	"F0,DSK,Mount Primary Floppy;",
+	"F1,DSK,Mount Secondary Floppy;",
+	"-;",
+	"S0,VHD,Mount HDD - SCSI2;",
+	"S1,VHD,Mount HDD - SCSI6 (boot);",
 	"-;",
 	"O8,Aspect ratio,4:3,16:9;",
-	"-;",
 	"O9A,Memory,512KB,1MB,4MB;",
 	"O5,Speed,Normal,Turbo;",
 	"-;",
@@ -214,9 +215,11 @@ wire  [1:0] diskMotor, diskAct, diskEject;
 // the status register is controlled by the on screen display (OSD)
 wire [31:0] status;
 wire  [1:0] buttons;
+wire  [2:0] img_mounted;
+wire [15:0] sd_req_type;
 wire [31:0] sd_lba;
-wire        sd_rd;
-wire        sd_wr;
+wire  [1:0] sd_rd;
+wire  [1:0] sd_wr;
 wire        sd_ack;
 wire  [8:0] sd_buff_addr;
 wire  [7:0] sd_buff_dout;
@@ -257,6 +260,9 @@ hps_io #(.STRLEN($size(CONF_STR)>>3)) hps_io
 	.buttons(buttons),
 	.status(status),
 
+	.img_mounted(img_mounted),
+	
+	.sd_req_type(sd_req_type),
 	.sd_lba(sd_lba),
 	.sd_rd(sd_rd),
 	.sd_wr(sd_wr),
@@ -463,7 +469,10 @@ dataController_top dc0
 	.diskMotor(diskMotor),
 	.diskAct(diskAct),
 
+	.img_mounted(img_mounted),
+	
 	// block device interface for scsi disk
+	.io_req_type(sd_req_type),
 	.io_lba(sd_lba),
 	.io_rd(sd_rd),
 	.io_wr(sd_wr),

--- a/MacPlus.sv
+++ b/MacPlus.sv
@@ -141,8 +141,8 @@ assign VIDEO_ARY = status[8] ? 8'd9  : 8'd3;
 localparam CONF_STR = {
 	"MACPLUS;;",
 	"-;",
-	"F0,DSK,Mount Primary Floppy;",
-	"F1,DSK,Mount Secondary Floppy;",
+	"F0,DSK,Mount Pri Floppy;",
+	"F1,DSK,Mount Sec Floppy;",
 	"-;",
 	"S0,VHD,Mount HDD - SCSI2;",
 	"S1,VHD,Mount HDD - SCSI6 (boot);",
@@ -314,6 +314,42 @@ TG68KdotC_Kernel #(0,0,0,0,0,0) m68k
 	.nResetOut      ( _cpuResetOut   ),
 	.FC             (                )
 );
+
+/*
+fx68k M68K
+(
+	.clk		( clk_sys ),
+	
+	.extReset( !_cpuReset ),
+	.pwrUp	( !_cpuReset ),
+	
+	.enPhi1	(M68K_CLKENp),
+	.enPhi2	(M68K_CLKENn),
+
+	.eRWn		( _cpuRW ),
+	.ASn		(M68K_AS_N),
+	.UDSn		( _cpuUDS ),
+	.LDSn		( _cpuLDS ),
+
+	.FC0(M68K_FC[0]),
+	.FC1(M68K_FC[1]),
+	.FC2(M68K_FC[2]),
+
+	.BGn(M68K_BG_N),
+	.BRn(M68K_BR_N),
+	.BGACKn(M68K_BGACK_N),
+
+	.DTACKn(M68K_MBUS_DTACK_N),
+	.VPAn(~M68K_INTACK),
+	.BERRn(1),
+	.IPL0n( _cpuIPL[0] ),
+	.IPL1n( _cpuIPL[1] ),
+	.IPL2n( _cpuIPL[2] ),
+	.iEdb( cpuDataIn ),
+	.oEdb( cpuDataOut ),
+	.eab( {cpuAddrHi, cpuAddr} )
+);
+*/
 
 assign VGA_R = {8{pixelOut}};
 assign VGA_G = {8{pixelOut}};

--- a/dataController_top.v
+++ b/dataController_top.v
@@ -67,9 +67,12 @@ module dataController_top(
 	input dskReadAckExt,
 
 	// connections to io controller
+	input   [1:0] img_mounted,
+	
+	output [15:0] io_req_type,
    output [31:0] io_lba,
-   output 	     io_rd,
-   output 	     io_wr,
+   output  [1:0] io_rd,
+   output  [1:0] io_wr,
    input 	     io_ack,
 
 	input   [8:0] sd_buff_addr,
@@ -161,6 +164,9 @@ ncr5380 scsi
 	.rdata(scsiDataOut),
 
 	// connections to io controller
+	.img_mounted( img_mounted ),
+	
+	.io_req_type( io_req_type ),
 	.io_lba ( io_lba ),
 	.io_rd ( io_rd ),
 	.io_wr ( io_wr ),

--- a/ncr5380.v
+++ b/ncr5380.v
@@ -284,8 +284,8 @@ module ncr5380
 	(
 		.clk    ( clk ),
 		.rst    ( scsi_rst ),
-		.sel    ( scsi_sel & img_mounted[0] ),
-		.atn    ( scsi_atn & img_mounted[0] ),
+		.sel    ( scsi_sel ),
+		.atn    ( scsi_atn ),
 		
 		.ack    ( scsi_ack ),
 		
@@ -323,8 +323,8 @@ module ncr5380
 	(
 		.clk		( clk ) ,			// input  clk
 		.rst		( scsi_rst ) ,		// input  rst
-		.sel		( scsi_sel & img_mounted[1] ) ,		// input  sel
-		.atn		( scsi_atn & img_mounted[1] ) ,		// input  atn
+		.sel		( scsi_sel ) ,		// input  sel
+		.atn		( scsi_atn ) ,		// input  atn
 		
 		.ack		( scsi_ack ) ,		// input  ack
 		

--- a/ncr5380.v
+++ b/ncr5380.v
@@ -13,7 +13,7 @@
 `define RREG_RST        3'h7    /* Reset */
 
 /* Write registers */
-`define WREG_ODR        3'h0    /* Ouptut data */
+`define WREG_ODR        3'h0    /* Output data */
 `define WREG_ICR        3'h1    /* Initiator Command */
 `define WREG_MR         3'h2    /* Mode register */
 `define WREG_TCR        3'h3    /* Target Command */
@@ -62,9 +62,12 @@ module ncr5380
 
 
 	// connections to io controller
+	input   [1:0] img_mounted,
+	
+	output [15:0] io_req_type,
 	output [31:0] io_lba,
-	output 	     io_rd,
-	output 	     io_wr,
+	output  [1:0] io_rd,
+	output  [1:0] io_wr,
 	input 	     io_ack,
 
 	input   [8:0] sd_buff_addr,
@@ -237,6 +240,7 @@ module ncr5380
    wire scsi_bsy = 
 		icr[`ICR_A_BSY] |
 		scsi2_bsy |
+		scsi6_bsy |
 		mr[`MR_ARB];
    
    /* Remains of simplified arbitration logic */
@@ -253,45 +257,98 @@ module ncr5380
    wire scsi_atn = icr[`ICR_A_ATN];
    
    /* Other trivial lines set by target */
-   wire scsi_cd = scsi2_cd;
-   wire scsi_io = scsi2_io;
-   wire scsi_msg = scsi2_msg;
-   wire scsi_req = scsi2_req;
-
-   assign din = scsi2_bsy?scsi2_dout:8'h55;
+   wire scsi_cd  = (scsi2_bsy) ? scsi2_cd : scsi6_cd;
+   wire scsi_io  = (scsi2_bsy) ? scsi2_io : scsi6_io;
+   wire scsi_msg = (scsi2_bsy) ? scsi2_msg : scsi6_msg;
+   wire scsi_req = (scsi2_bsy) ? scsi2_req : scsi6_req;
+	
+   assign din = scsi2_bsy ? scsi2_dout : 
+					 scsi6_bsy ? scsi6_dout : 
+					                 8'h55;
    
+	assign io_lba      = (scsi2_bsy) ? io_lba_2 : io_lba_6;
+	assign sd_buff_din = (scsi2_bsy) ? sd_buff_din_2 : sd_buff_din_6;
+	assign sd_req_type = 16'h0000;	// Not used atm. Could be used for CD-ROM sector requests later. ElectronAsh.
+	
+	
    // input signals from target 2
    wire scsi2_bsy, scsi2_msg, scsi2_io, scsi2_cd, scsi2_req;
    wire [7:0] scsi2_dout;
+	
+	wire [31:0] io_lba_2;
+	wire [7:0] sd_buff_din_2;
 
+	
    // connect a target
    scsi #(.ID(2)) scsi2
 	(
 		.clk    ( clk ),
 		.rst    ( scsi_rst ),
-		.sel    ( scsi_sel ),
-		.atn    ( scsi_atn ),
+		.sel    ( scsi_sel & img_mounted[0] ),
+		.atn    ( scsi_atn & img_mounted[0] ),
+		
+		.ack    ( scsi_ack ),
+		
 		.bsy    ( scsi2_bsy ),
 		.msg    ( scsi2_msg ),
 		.cd     ( scsi2_cd ),
 		.io     ( scsi2_io ),
 		.req    ( scsi2_req ),
-		.ack    ( scsi_ack ),
 		.dout   ( scsi2_dout ),
+		
 		.din    ( dout ),
 
 		// connection to io controller to read and write sectors
 		// to sd card
-		.io_lba ( io_lba ),
-		.io_rd  ( io_rd ),
-		.io_wr  ( io_wr ),
-		.io_ack ( io_ack ),
+		.io_lba ( io_lba_2 ),
+		.io_rd  ( io_rd[0] ),
+		.io_wr  ( io_wr[0] ),
+		.io_ack ( io_ack & scsi2_bsy ),
 
-		.sd_buff_addr(sd_buff_addr),
-		.sd_buff_dout(sd_buff_dout),
-		.sd_buff_din(sd_buff_din),
-		.sd_buff_wr(sd_buff_wr)
+		.sd_buff_addr( sd_buff_addr ),
+		.sd_buff_dout( sd_buff_dout ),
+		.sd_buff_din( sd_buff_din_2 ),
+		.sd_buff_wr( sd_buff_wr & scsi2_bsy )
 	);
+
    
-   
+   // input signals from target 6
+   wire scsi6_bsy, scsi6_msg, scsi6_io, scsi6_cd, scsi6_req;
+   wire [7:0] scsi6_dout;
+	
+	wire [31:0] io_lba_6;
+	wire [7:0] sd_buff_din_6;
+
+   scsi #(.ID(6)) scsi6
+	(
+		.clk		( clk ) ,			// input  clk
+		.rst		( scsi_rst ) ,		// input  rst
+		.sel		( scsi_sel & img_mounted[1] ) ,		// input  sel
+		.atn		( scsi_atn & img_mounted[1] ) ,		// input  atn
+		
+		.ack		( scsi_ack ) ,		// input  ack
+		
+		.bsy		( scsi6_bsy ) ,	// output  bsy
+		.msg		( scsi6_msg ) ,	// output  msg
+		.cd		( scsi6_cd ) ,		// output  cd
+		.io		( scsi6_io ) ,		// output  io
+		.req		( scsi6_req ) ,	// output  req
+		.dout		( scsi6_dout ) ,	// output [7:0] dout
+		
+		.din		( dout ) ,			// input [7:0] din
+		
+		// connection to io controller to read and write sectors
+		// to sd card
+		.io_lba	( io_lba_6 ) ,		// output [31:0] io_lba
+		.io_rd	( io_rd[1] ) ,		// output  io_rd
+		.io_wr	( io_wr[1] ) ,		// output  io_wr
+		.io_ack	( io_ack & scsi6_bsy ) ,		// input  io_ack
+		
+		.sd_buff_addr( sd_buff_addr ) ,	// input [8:0] sd_buff_addr
+		.sd_buff_dout( sd_buff_dout ) ,	// input [7:0] sd_buff_dout
+		.sd_buff_din( sd_buff_din_6 ) ,	// output [7:0] sd_buff_din
+		.sd_buff_wr( sd_buff_wr & scsi6_bsy ) 	// input  sd_buff_wr
+	);
+
+
 endmodule

--- a/scsi.v
+++ b/scsi.v
@@ -104,11 +104,12 @@ wire [7:0] inquiry_dout =
 
 		(data_cnt == 32'd26)?"S":(data_cnt == 32'd27)?"T":
 		(data_cnt == 32'd28)?"2":(data_cnt == 32'd29)?"2":
-		(data_cnt == 32'd30)?"5":(data_cnt == 32'd31)?"N":
+		(data_cnt == 32'd30)?"5":(data_cnt == 32'd31)?"N" + ID:	// TESTING. ElectronAsh.
 		8'h00;
 
 // output of read capacity command
-wire [31:0] capacity = 32'd41056;   // 40960 + 96 blocks = 20MB
+//wire [31:0] capacity = 32'd41056;   // 40960 + 96 blocks = 20MB
+wire [31:0] capacity = 32'd1024096;   // 1024000 + 96 blocks = 500MB
 wire [31:0] capacity_m1 = capacity - 32'd1;
 wire [7:0] read_capacity_dout =
 		(data_cnt == 32'd0 )?capacity_m1[31:24]:

--- a/sys/hps_io.v
+++ b/sys/hps_io.v
@@ -28,7 +28,7 @@
 
 // WIDE=1 for 16 bit file I/O
 // VDNUM 1-4
-module hps_io #(parameter STRLEN=0, PS2DIV=0, WIDE=0, VDNUM=1, PS2WE=0)
+module hps_io #(parameter STRLEN=0, PS2DIV=0, WIDE=0, VDNUM=2, PS2WE=0)
 (
 	input             clk_sys,
 	inout      [45:0] HPS_BUS,


### PR DESCRIPTION
The two SCSI devices are detected and working now, but the HPS currently won't save the config for the VHD filenames. Maybe some support code on the HPS side is needed?

The core also doesn't seem to reset properly from the OSD menu atm? Often just gets a blank screen.

So to test atm, the two VHDs have to be quickly loaded from the OSD one after the other, so best to mount the "boot" drive before the first one.

If that happens before the "Welcome to Macintosh" message appears, it usually picks up both drives / VHDs.

Drive capacity was changed from 20MB to 500MB, to test larger VHD images.


Changes done with help from alanswx. ;)