### PR TITLE
Simple fix for audio - when sound output is disabled, drive output high instead of zero

### DIFF
--- a/rtl/dataController_top.sv
+++ b/rtl/dataController_top.sv
@@ -114,7 +114,7 @@ module dataController_top(
 	reg [7:0] audio_latch;
 	always @(posedge clk32) begin
 		if(clk8_en_p && loadSoundD) begin
-			if(snd_ena) audio_latch <= 8'h00;
+			if(snd_ena) audio_latch <= 8'h7f; // when disabled, drive output high
 			else  	 	audio_latch <= memoryDataIn[15:8] - 8'd128;
 		end
 	end


### PR DESCRIPTION
The original sound hardware is TTL - so can only ever be 0 or 1. We're driving it more like a DAC here, so drive it to the highest value when disabled